### PR TITLE
Mac OSX compatibility (readlink -f issue)

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -25,16 +25,33 @@ efunctions_indent()
   done
 }
 
-abspath()
-{
-  case $OSTYPE in
-    darwin*)
-      readlink "$1"
-      ;;
-    *)
-      readlink -f "$1"
-      ;;
-  esac
+# http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+function abspath {
+
+  if readlink -f $0 2>&1 | grep -q 'readlink: illegal option -- f'; then
+    TARGET_FILE=$1
+
+    cd `dirname $TARGET_FILE`
+
+    TARGET_FILE=`basename $TARGET_FILE`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+      TARGET_FILE=`readlink $TARGET_FILE`
+      cd `dirname $TARGET_FILE`
+      TARGET_FILE=`basename $TARGET_FILE`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT=$PHYS_DIR/$TARGET_FILE
+  else
+    RESULT=$(readlink -f $0)
+  fi
+
+  echo $RESULT
 }
 
 export -f 'efunctions_indent'

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,30 @@
-abspath()
-{
-  case $OSTYPE in
-    darwin*)
-      readlink "$1"
-      ;;
-    *)
-      readlink -f "$1"
-      ;;
-  esac
+# http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+function abspath {
+
+  if readlink -f $0 2>&1 | grep -q 'readlink: illegal option -- f'; then
+    TARGET_FILE=$1
+
+    cd `dirname $TARGET_FILE`
+
+    TARGET_FILE=`basename $TARGET_FILE`
+
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "$TARGET_FILE" ]
+    do
+      TARGET_FILE=`readlink $TARGET_FILE`
+      cd `dirname $TARGET_FILE`
+      TARGET_FILE=`basename $TARGET_FILE`
+    done
+
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    PHYS_DIR=`pwd -P`
+    RESULT=$PHYS_DIR/$TARGET_FILE
+  else
+    RESULT=$(readlink -f $0)
+  fi
+
+  echo $RESULT
 }
 
 #HERE=$(readlink -f "$0")


### PR DESCRIPTION
Implemented shim based on whether readlink -f throws an illegal operation error as recommended by http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac

Feel free to tidy up the implementation, but have tested from install on both Mac OSX 10.8 (mountain lion) and Ubuntu 12.04 (precise) and both install.sh and test.sh scripts are working correctly.
