### PR TITLE
fix(eend): Gracefully handle being called without any args.

### DIFF
--- a/efunctions/eend
+++ b/efunctions/eend
@@ -1,7 +1,5 @@
-P=$1
+P=${1:-0}
 [ "$2" != "" ] && MSG="$(echo $@ | cut -d ' ' -f 2-)" || MSG=""
-
-eval $(eval_ecolors)
 
 eval $(eval_ecolors)
 

--- a/efunctions/ewend
+++ b/efunctions/ewend
@@ -1,7 +1,5 @@
-P=$1
+P=${1:-0}
 MSG="$(echo $@ | cut -d ' ' -f 2-)"
-
-eval $(eval_ecolors)
 
 eval $(eval_ecolors)
 


### PR DESCRIPTION
The implementation of eend in OpenRC treats no arguments as a successful
status. This appears to be unintentional based on the code but it is
behavior that the ccache-config script depends on.
