### PR TITLE
rc-status

### DIFF
--- a/efunctions/rc-status
+++ b/efunctions/rc-status
@@ -61,24 +61,24 @@ all_services="$(map_keys services | sort | uniq)"
 for service in $all_services; do
 	running="$(map_get running "$service")"
 
-	src=""
+	service_name="$(printf "%-40s" "$service")"
+	src="${BRACKET}"
 	if [ "$(map_get is_upstart "$service")" = "yes" ]; then
-		src=" ${BRACKET}(upstart)"
-	else
-		if [ "$(map_get is_sysv "$service")" = "yes" ]; then
-			src=" ${BRACKET}(system V)"
-		fi
+		src="$src  upstart"
+	fi
+	if [ "$(map_get is_sysv "$service")" = "yes" ]; then
+		src="$src  system V"
 	fi
 
 	if [ "yes" = "$running" ]; then
-		einfo "$bold$service$src"
+		einfo "$bold$service_name$src"
 		eend 0
 	else
 		if [ "no" = "$running" ]; then
-			eerror "$service$src"
+			eerror "$service_name$src"
 			eend 1
 		else
-			ewarn "$service$src"
+			ewarn "$service_name$src"
 			eend 1
 		fi
 	fi

--- a/efunctions/rc-status
+++ b/efunctions/rc-status
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Copyright (c) 2016 Marcus Downing <marcus.downing@gmail.com>
+# Released under the 2-clause BSD license.
+
+. ../functions.sh
+. efunctions_ecolors
+
+command_exists() {
+	command -v "$1" >/dev/null 2>/dev/null
+}
+
+# cf
+map_put () {
+    alias "hash__${1}$2"="$3"
+}
+
+map_get() {
+    alias "hash__${1}$2" 2>/dev/null | awk -F"'" '{ print $2; }'
+}
+
+map_keys() {
+    alias | grep '^hash__'$1 | cut -d'=' -f1 | awk -F"$1" '{print $2; }'
+}
+
+
+# System V jobs
+if command_exists service; then
+	for service in $(service --status-all 2>&1 | cut -c 9-); do
+		map_put services "$service"
+		map_put is_sysv "$service" yes
+
+		if service "$service" status >/dev/null 2>&1; then
+			map_put running "$service" "yes"
+		else
+			map_put running "$service" "no"
+		fi
+	done
+fi
+
+# Upstart jobs
+if command_exists initctl; then
+	for service in `initctl list | cut -d ' ' -f 1`; do
+		map_put services "$service"
+		map_put is_upstart "$service" yes
+		map_put status "$service" "no"
+
+		if initctl status "$service" 2>&1 | grep "start/running" >/dev/null; then
+			map_put running "$service" "yes"
+		else
+			map_put running "$service" "no"
+		fi
+	done
+fi
+
+# TODO systemd?
+
+# Output
+bold=`tput bold`
+
+all_services="$(map_keys services | sort | uniq)"
+for service in $all_services; do
+	running="$(map_get running "$service")"
+
+	src=""
+	if [ "$(map_get is_upstart "$service")" = "yes" ]; then
+		src=" ${BRACKET}(upstart)"
+	else
+		if [ "$(map_get is_sysv "$service")" = "yes" ]; then
+			src=" ${BRACKET}(system V)"
+		fi
+	fi
+
+	if [ "yes" = "$running" ]; then
+		einfo "$bold$service$src"
+		eend 0
+	else
+		if [ "no" = "$running" ]; then
+			eerror "$service$src"
+			eend 1
+		else
+			ewarn "$service$src"
+			eend 1
+		fi
+	fi
+done

--- a/efunctions/rc-status
+++ b/efunctions/rc-status
@@ -31,8 +31,8 @@ if command_exists service; then
 
 		if service "$service" status >/dev/null 2>&1; then
 			map_put running "$service" "yes"
-		else
-			map_put running "$service" "no"
+		# else
+			# map_put running "$service" "no"
 		fi
 	done
 fi
@@ -46,8 +46,13 @@ if command_exists initctl; then
 
 		if initctl status "$service" 2>&1 | grep "start/running" >/dev/null; then
 			map_put running "$service" "yes"
-		else
-			map_put running "$service" "no"
+
+			pid="$(initctl status "$service" | grep -o 'process [0-9]\+' | sed 's/^process //')"
+			if [ ! -z "$pid" ]; then
+				map_put pid "$service" "$pid"
+			fi
+		# else
+			# map_put running "$service" "no"
 		fi
 	done
 fi
@@ -65,21 +70,24 @@ for service in $all_services; do
 	src="${BRACKET}"
 	if [ "$(map_get is_upstart "$service")" = "yes" ]; then
 		src="$src  upstart"
+	else
+		src="$src         "
 	fi
 	if [ "$(map_get is_sysv "$service")" = "yes" ]; then
-		src="$src  system V"
+		src="$src  sysV"
+	else
+		src="$src      "
 	fi
 
+	pid="$NORMAL  $(printf "%6s" "$(map_get pid "$service")")"
+
 	if [ "yes" = "$running" ]; then
-		einfo "$bold$service_name$src"
-		eend 0
+		einfo "$bold$service_name$src$pid"
 	else
-		if [ "no" = "$running" ]; then
-			eerror "$service_name$src"
-			eend 1
+		if [ "no" = "$running" -o "" = "$running" ]; then
+			eerror "$service_name$src$pid"
 		else
-			ewarn "$service_name$src"
-			eend 1
+			ewarn "$service_name$src$pid"
 		fi
 	fi
 done


### PR DESCRIPTION
I've always found that the Ubuntu mechanisms for listing running services were significantly less clear than Gentoo's `rc-status` command.

This change adds an `rc-status` command to efunctions. It attempts to detect the presence of System V init, Upstart and Systemd, rather than presuming they'll work; and normalised the output. It does **not** attempt to mimic the output format of the old `rc-status` command.

**WIP**

This is a work in progress. Do not trust it yet.