### PR TITLE
Indent nesting

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -60,4 +60,7 @@ if [ -z "$TERMINFO" ]; then
 fi
 
 export EFUNCTIONS_ECHO="$(which echo)"
-export EINFO_INDENT=0
+if [ "yes" != "$EFUNCTIONS_LOADED" ]; then
+	export EINFO_INDENT=0
+fi
+export EFUNCTIONS_LOADED="yes"


### PR DESCRIPTION
## Because

Sometimes you want to run a script that uses efunctions inside another script that uses efunctions, and have them respect the indentation you've set with `indent` and `eoutdent`.

## This change

Prevents the setting of `EINFO_INDENT` to 0 when it finds `EFUNCTIONS_LOADED` already set.