### PR TITLE
Dumb terminal

### DIFF
--- a/efunctions/efunctions_ecolors
+++ b/efunctions/efunctions_ecolors
@@ -24,7 +24,7 @@ else
 		BRACKET=`tput sgr0; tput bold; tput setaf 4`
 		NORMAL=`tput sgr0`
 	else
-		if tty -s; then
+		if [ -t 0 ]; then
 			#echo "Fallback colours" 1>&2
 			GOOD="$(/bin/echo -e "\e[1;32m")"
 			WARN="$(/bin/echo -e "\e[1;33m")"

--- a/efunctions/efunctions_ecolors
+++ b/efunctions/efunctions_ecolors
@@ -2,6 +2,10 @@
 # Copyright (c) 2015 Marcus Downing <marcus.downing@gmail.com>
 # Released under the 2-clause BSD license.
 
+if [ -z "$TERM" ]; then
+	TERM="dumb"
+fi
+
 if tput setf 1 >/dev/null 2>&1; then
 	#echo "Standard colours" 1>&2
 	GOOD=`tput sgr0; tput bold; tput setf 2`
@@ -20,13 +24,23 @@ else
 		BRACKET=`tput sgr0; tput bold; tput setaf 4`
 		NORMAL=`tput sgr0`
 	else
-		#echo "Fallback colours" 1>&2
-		GOOD="$(/bin/echo -e "\e[1;32m")"
-		WARN="$(/bin/echo -e "\e[1;33m")"
-		BAD="$(/bin/echo -e "\e[1;31m")"
-		HILITE="$(/bin/echo -e "\e[1;36m")"
-		BRACKET="$(/bin/echo -e "\e[1;34m")"
-		NORMAL="$(/bin/echo -e "\e[0m")"
+		if tty -s; then
+			#echo "Fallback colours" 1>&2
+			GOOD="$(/bin/echo -e "\e[1;32m")"
+			WARN="$(/bin/echo -e "\e[1;33m")"
+			BAD="$(/bin/echo -e "\e[1;31m")"
+			HILITE="$(/bin/echo -e "\e[1;36m")"
+			BRACKET="$(/bin/echo -e "\e[1;34m")"
+			NORMAL="$(/bin/echo -e "\e[0m")"
+		else
+			#echo "No colours" 1>&2
+			GOOD=''
+			WARN=''
+			BAD=''
+			HILITE=''
+			BRACKET=''
+			NORMAL=''
+		fi
 	fi
 fi
 


### PR DESCRIPTION
## Because

Sometimes scripts using these efunctions are called in a non-interactive context such as
 - Regularly by Cron
 - Remotely by Ansible, Puppet or Chef
 - An automatic installer
 - As part of a remote script

In these cases the terminal has fewer features than normal, and may be lacking a value for `$TERM`.

## This change

1. Sets `$TERM` value to `dumb` if it's unset, preventing `tput` from printing an error message.
2. Turns colours off in completely non-interactive terminals.
